### PR TITLE
Avoid calling android methods from tests

### DIFF
--- a/verticalstepper/src/main/java/com/snowble/android/verticalstepper/VerticalStepper.java
+++ b/verticalstepper/src/main/java/com/snowble/android/verticalstepper/VerticalStepper.java
@@ -271,6 +271,11 @@ public class VerticalStepper extends ViewGroup {
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
+        initChildViews();
+    }
+
+    @VisibleForTesting
+    void initChildViews() {
         int childCount = getChildCount();
         for (int i = 0; i < childCount; i++) {
             initInnerView(getChildAt(i));

--- a/verticalstepper/src/test/java/com/snowble/android/verticalstepper/VerticalStepperTest.java
+++ b/verticalstepper/src/test/java/com/snowble/android/verticalstepper/VerticalStepperTest.java
@@ -286,7 +286,7 @@ public class VerticalStepperTest {
         mockLayoutParamsHeights(titleBottom, summaryBottom);
 
         stepper.addView(mockInnerView);
-        stepper.onAttachedToWindow();
+        stepper.initChildViews();
 
         testSingleChildInactiveMeasurement(innerViewMeasuredWidth, titleBottom, summaryBottom);
         testSingleChildActiveMeasurement(innerViewMeasuredWidth, innerViewMeasuredHeight,


### PR DESCRIPTION
The android method/callback is not indicative of the actual
functionality. Add explicit methods that are indicative.