### PR TITLE
Remove redundant tests

### DIFF
--- a/verticalstepper/src/main/java/com/snowble/android/verticalstepper/VerticalStepper.java
+++ b/verticalstepper/src/main/java/com/snowble/android/verticalstepper/VerticalStepper.java
@@ -511,23 +511,23 @@ public class VerticalStepper extends ViewGroup {
     }
 
     @VisibleForTesting
-    int calculateVerticalPadding() {
-        return outerVerticalPadding + outerVerticalPadding + getPaddingTop() + getPaddingBottom();
-    }
-
-    @VisibleForTesting
     int calculateHorizontalPadding() {
         return outerHorizontalPadding + outerHorizontalPadding + getPaddingLeft() + getPaddingRight();
     }
 
     @VisibleForTesting
-    int calculateInnerViewVerticalUsedSpace(LayoutParams lp) {
-        return lp.topMargin + lp.bottomMargin;
+    int calculateVerticalPadding() {
+        return outerVerticalPadding + outerVerticalPadding + getPaddingTop() + getPaddingBottom();
     }
 
     @VisibleForTesting
     int calculateInnerViewHorizontalUsedSpace(LayoutParams lp) {
         return iconDimension + iconMarginRight + lp.leftMargin + lp.rightMargin;
+    }
+
+    @VisibleForTesting
+    int calculateInnerViewVerticalUsedSpace(LayoutParams lp) {
+        return lp.topMargin + lp.bottomMargin;
     }
 
     @VisibleForTesting

--- a/verticalstepper/src/test/java/com/snowble/android/verticalstepper/VerticalStepperTest.java
+++ b/verticalstepper/src/test/java/com/snowble/android/verticalstepper/VerticalStepperTest.java
@@ -684,7 +684,7 @@ public class VerticalStepperTest {
     }
 
     @Test
-    public void calculateStepDecoratorTextWidth_TallerTitle_ShouldReturnTitle() {
+    public void calculateStepDecoratorTextWidth_WiderTitle_ShouldReturnTitle() {
         mockLayoutParamsWidths(20f, 10f);
 
         float width = stepper.calculateStepDecoratorTextWidth(mockLayoutParams1);
@@ -693,7 +693,7 @@ public class VerticalStepperTest {
     }
 
     @Test
-    public void calculateStepDecoratorTextWidth_TallerSummary_ShouldReturnSummary() {
+    public void calculateStepDecoratorTextWidth_WiderSummary_ShouldReturnSummary() {
         mockLayoutParamsWidths(20f, 25f);
 
         float width = stepper.calculateStepDecoratorTextWidth(mockLayoutParams1);

--- a/verticalstepper/src/test/java/com/snowble/android/verticalstepper/VerticalStepperTest.java
+++ b/verticalstepper/src/test/java/com/snowble/android/verticalstepper/VerticalStepperTest.java
@@ -200,40 +200,52 @@ public class VerticalStepperTest {
     }
 
     @Test
-    public void calculateHorizontalPadding_ShouldReturnAllPadding() {
-        int horizontalPadding = stepper.calculateHorizontalPadding();
+    public void doMeasurement_NoStepsUnspecifiedSpecs_ShouldMeasurePadding() {
+        int ms = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
 
-        assertThat(horizontalPadding)
-                .isEqualTo((stepper.outerHorizontalPadding * 2) +
-                        stepper.getPaddingLeft() + stepper.getPaddingRight());
+        stepper.doMeasurement(ms, ms);
+
+        assertThat(stepper.getMeasuredHeight()).isEqualTo(stepper.calculateVerticalPadding());
+        assertThat(stepper.getMeasuredWidth()).isEqualTo(stepper.calculateHorizontalPadding());
     }
 
     @Test
-    public void calculateVerticalPadding_ShouldReturnAllPadding() {
-        int verticalPadding = stepper.calculateVerticalPadding();
+    public void doMeasurement_NoStepsAtMostSpecsRequiresClipping_ShouldMeasureToAtMostValues() {
+        int width = stepper.calculateHorizontalPadding() / 2;
+        int height = stepper.calculateVerticalPadding() / 2;
+        int wms = View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.AT_MOST);
+        int hms = View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.AT_MOST);
 
-        assertThat(verticalPadding)
-                .isEqualTo((stepper.outerVerticalPadding * 2) +
-                        stepper.getPaddingTop() + stepper.getPaddingBottom());
+        stepper.doMeasurement(wms, hms);
+
+        assertThat(stepper.getMeasuredWidth()).isEqualTo(width);
+        assertThat(stepper.getMeasuredHeight()).isEqualTo(height);
     }
 
     @Test
-    public void calculateInnerViewHorizontalUsedSpace_ShouldReturnPaddingAndIconLeftAdjustment() {
-        VerticalStepper.LayoutParams lp = createTestLayoutParams(20, 0, 10, 0);
+    public void doMeasurement_NoStepsExactlySpecsRequiresClipping_ShouldMeasureToExactValues() {
+        int width = stepper.calculateHorizontalPadding() / 2;
+        int height = stepper.calculateVerticalPadding() / 2;
+        int wms = View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY);
+        int hms = View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY);
 
-        int horizontalPadding = stepper.calculateInnerViewHorizontalUsedSpace(lp);
+        stepper.doMeasurement(wms, hms);
 
-        assertThat(horizontalPadding)
-                .isEqualTo(lp.leftMargin + lp.rightMargin + stepper.iconDimension + stepper.iconMarginRight);
+        assertThat(stepper.getMeasuredWidth()).isEqualTo(width);
+        assertThat(stepper.getMeasuredHeight()).isEqualTo(height);
     }
 
     @Test
-    public void calculateInnerViewVerticalUsedSpace_ShouldReturnAllMargins() {
-        VerticalStepper.LayoutParams lp = createTestLayoutParams(0, 10, 0, 20);
+    public void doMeasurement_NoStepsExactlySpecsRequiresExpanding_ShouldMeasureToExactValues() {
+        int width = stepper.calculateHorizontalPadding() * 2;
+        int height = stepper.calculateVerticalPadding() * 2;
+        int wms = View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY);
+        int hms = View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY);
 
-        int verticalPadding = stepper.calculateInnerViewVerticalUsedSpace(lp);
+        stepper.doMeasurement(wms, hms);
 
-        assertThat(verticalPadding).isEqualTo(lp.topMargin + lp.bottomMargin);
+        assertThat(stepper.getMeasuredWidth()).isEqualTo(width);
+        assertThat(stepper.getMeasuredHeight()).isEqualTo(height);
     }
 
     @Test
@@ -597,55 +609,6 @@ public class VerticalStepperTest {
     }
 
     @Test
-    public void doMeasurement_NoStepsUnspecifiedSpecs_ShouldMeasurePadding() {
-        int ms = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
-
-        stepper.doMeasurement(ms, ms);
-
-        assertThat(stepper.getMeasuredHeight()).isEqualTo(stepper.calculateVerticalPadding());
-        assertThat(stepper.getMeasuredWidth()).isEqualTo(stepper.calculateHorizontalPadding());
-    }
-
-    @Test
-    public void doMeasurement_NoStepsAtMostSpecsRequiresClipping_ShouldMeasureToAtMostValues() {
-        int width = stepper.calculateHorizontalPadding() / 2;
-        int height = stepper.calculateVerticalPadding() / 2;
-        int wms = View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.AT_MOST);
-        int hms = View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.AT_MOST);
-
-        stepper.doMeasurement(wms, hms);
-
-        assertThat(stepper.getMeasuredWidth()).isEqualTo(width);
-        assertThat(stepper.getMeasuredHeight()).isEqualTo(height);
-    }
-
-    @Test
-    public void doMeasurement_NoStepsExactlySpecsRequiresClipping_ShouldMeasureToExactValues() {
-        int width = stepper.calculateHorizontalPadding() / 2;
-        int height = stepper.calculateVerticalPadding() / 2;
-        int wms = View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY);
-        int hms = View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY);
-
-        stepper.doMeasurement(wms, hms);
-
-        assertThat(stepper.getMeasuredWidth()).isEqualTo(width);
-        assertThat(stepper.getMeasuredHeight()).isEqualTo(height);
-    }
-
-    @Test
-    public void doMeasurement_NoStepsExactlySpecsRequiresExpanding_ShouldMeasureToExactValues() {
-        int width = stepper.calculateHorizontalPadding() * 2;
-        int height = stepper.calculateVerticalPadding() * 2;
-        int wms = View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY);
-        int hms = View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.EXACTLY);
-
-        stepper.doMeasurement(wms, hms);
-
-        assertThat(stepper.getMeasuredWidth()).isEqualTo(width);
-        assertThat(stepper.getMeasuredHeight()).isEqualTo(height);
-    }
-
-    @Test
     public void measureTouchView_ShouldMeasureWidthAndHeightExactly() {
         ArgumentCaptor<Integer> wmsCaptor = ArgumentCaptor.forClass(Integer.class);
         ArgumentCaptor<Integer> hmsCaptor = ArgumentCaptor.forClass(Integer.class);
@@ -662,6 +625,43 @@ public class VerticalStepperTest {
         int actualHms = hmsCaptor.getValue();
         assertThat(View.MeasureSpec.getMode(actualHms)).isEqualTo(View.MeasureSpec.EXACTLY);
         assertThat(View.MeasureSpec.getSize(actualHms)).isEqualTo(stepper.touchViewHeight);
+    }
+
+    @Test
+    public void calculateHorizontalPadding_ShouldReturnAllPadding() {
+        int horizontalPadding = stepper.calculateHorizontalPadding();
+
+        assertThat(horizontalPadding)
+                .isEqualTo((stepper.outerHorizontalPadding * 2) +
+                        stepper.getPaddingLeft() + stepper.getPaddingRight());
+    }
+
+    @Test
+    public void calculateVerticalPadding_ShouldReturnAllPadding() {
+        int verticalPadding = stepper.calculateVerticalPadding();
+
+        assertThat(verticalPadding)
+                .isEqualTo((stepper.outerVerticalPadding * 2) +
+                        stepper.getPaddingTop() + stepper.getPaddingBottom());
+    }
+
+    @Test
+    public void calculateInnerViewHorizontalUsedSpace_ShouldReturnPaddingAndIconLeftAdjustment() {
+        VerticalStepper.LayoutParams lp = createTestLayoutParams(20, 0, 10, 0);
+
+        int horizontalPadding = stepper.calculateInnerViewHorizontalUsedSpace(lp);
+
+        assertThat(horizontalPadding)
+                .isEqualTo(lp.leftMargin + lp.rightMargin + stepper.iconDimension + stepper.iconMarginRight);
+    }
+
+    @Test
+    public void calculateInnerViewVerticalUsedSpace_ShouldReturnAllMargins() {
+        VerticalStepper.LayoutParams lp = createTestLayoutParams(0, 10, 0, 20);
+
+        int verticalPadding = stepper.calculateInnerViewVerticalUsedSpace(lp);
+
+        assertThat(verticalPadding).isEqualTo(lp.topMargin + lp.bottomMargin);
     }
 
     @Test
@@ -821,5 +821,4 @@ public class VerticalStepperTest {
         lp.height = VerticalStepper.LayoutParams.WRAP_CONTENT;
         return lp;
     }
-
 }

--- a/verticalstepper/src/test/java/com/snowble/android/verticalstepper/VerticalStepperTest.java
+++ b/verticalstepper/src/test/java/com/snowble/android/verticalstepper/VerticalStepperTest.java
@@ -646,63 +646,6 @@ public class VerticalStepperTest {
     }
 
     @Test
-    public void doMeasurement_OneStepUnspecifiedSpec_ShouldMeasurePaddingStepDecorationsAndInnerView() {
-        int innerViewMeasuredWidth = 100;
-        int innerViewMeasuredHeight = 400;
-        mockInnerViewMeasurements(innerViewMeasuredWidth, innerViewMeasuredHeight);
-
-        int buttonMeasuredWidth = 80;
-        int buttonMeasuredHeight = 20;
-        mockContinueButtonMeasurements(buttonMeasuredWidth, buttonMeasuredHeight);
-
-        float titleWidth = 10f;
-        float summaryWidth = 20f;
-        mockLayoutParamsWidths(titleWidth, summaryWidth);
-
-        float titleBottom = 24f;
-        float summaryBottom = 20f;
-        mockLayoutParamsHeights(titleBottom, summaryBottom);
-
-        initOneStep();
-
-        testSingleChildInactiveMeasurement(innerViewMeasuredWidth, titleBottom, summaryBottom);
-        testSingleChildActiveMeasurement(innerViewMeasuredWidth, innerViewMeasuredHeight,
-                titleBottom, summaryBottom,
-                buttonMeasuredHeight);
-    }
-
-    private void testSingleChildInactiveMeasurement(int innerViewMeasuredWidth,
-                                                    float titleBottom, float summaryBottom) {
-        when(mockLayoutParams1.isActive()).thenReturn(false);
-        int ms = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
-
-        stepper.doMeasurement(ms, ms);
-
-        assertThat(stepper.getMeasuredWidth())
-                .isEqualTo(stepper.calculateHorizontalPadding() + stepper.calculateInnerViewHorizontalUsedSpace(mockLayoutParams1)
-                + innerViewMeasuredWidth);
-        assertThat(stepper.getMeasuredHeight())
-                .isEqualTo(stepper.calculateVerticalPadding() + stepper.calculateInnerViewVerticalUsedSpace(mockLayoutParams1)
-                + (int) (titleBottom + summaryBottom));
-    }
-
-    private void testSingleChildActiveMeasurement(int innerViewMeasuredWidth, int innerViewMeasuredHeight,
-                                                  float titleBottom, float summaryBottom,
-                                                  int buttonMeasuredHeight) {
-        when(mockLayoutParams1.isActive()).thenReturn(true);
-        int ms = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
-
-        stepper.doMeasurement(ms, ms);
-
-        assertThat(stepper.getMeasuredWidth())
-                .isEqualTo(stepper.calculateHorizontalPadding() + stepper.calculateInnerViewHorizontalUsedSpace(mockLayoutParams1)
-                        + innerViewMeasuredWidth);
-        assertThat(stepper.getMeasuredHeight())
-                .isEqualTo(stepper.calculateVerticalPadding() + stepper.calculateInnerViewVerticalUsedSpace(mockLayoutParams1)
-                        + (int) (titleBottom + summaryBottom) + innerViewMeasuredHeight + buttonMeasuredHeight);
-    }
-
-    @Test
     public void measureTouchView_ShouldMeasureWidthAndHeightExactly() {
         ArgumentCaptor<Integer> wmsCaptor = ArgumentCaptor.forClass(Integer.class);
         ArgumentCaptor<Integer> hmsCaptor = ArgumentCaptor.forClass(Integer.class);
@@ -837,16 +780,6 @@ public class VerticalStepperTest {
                                                      List<Integer> bottomMarginHeights) {
         stepper.decoratorHeights.addAll(decoratorHeights);
         stepper.bottomMarginHeights.addAll(bottomMarginHeights);
-    }
-
-    private void mockInnerViewMeasurements(int measuredWidth, int measuredHeight) {
-        when(mockInnerView1.getMeasuredWidth()).thenReturn(measuredWidth);
-        when(mockInnerView1.getMeasuredHeight()).thenReturn(measuredHeight);
-    }
-
-    private void mockContinueButtonMeasurements(int measuredWidth, int measuredHeight) {
-        when(mockContinueButton1.getMeasuredWidth()).thenReturn(measuredWidth);
-        when(mockContinueButton1.getMeasuredHeight()).thenReturn(measuredHeight);
     }
 
     private void mockLayoutParamsWidths(float titleWidth, float summaryWidth) {


### PR DESCRIPTION
Child measurements are being tested by the measureChildViews_* tests.
Testing them via doMeasure() is redundant.